### PR TITLE
Fix Api-subscriber's onCompleted call before realm data is loaded

### DIFF
--- a/apiclient/src/main/java/io/fabianterhorst/apiclient/ApiObserver.java
+++ b/apiclient/src/main/java/io/fabianterhorst/apiclient/ApiObserver.java
@@ -44,8 +44,8 @@ public class ApiObserver extends ApiStorage implements IApiObserver {
                     .compose(applySchedulers())
                     .compose(getLifecycle());
             return Observable.<List<Item>>create(subscriber -> {
-                realmObserver.subscribe(subscriber::onNext, subscriber::onError);
-                retrofitObserver.subscribe(this::setItems, subscriber::onError, subscriber::onCompleted);
+                realmObserver.take(2).subscribe(subscriber::onNext, subscriber::onError, subscriber::onCompleted);
+                retrofitObserver.subscribe(this::setItems, subscriber::onError);
             }).compose(getLifecycle());
         } else
             return api;


### PR DESCRIPTION
We need to take 2 first items from realm: 1) from current realm state 2) from updated realm state (after data is loaded via retrofit). Only then subscriber should be closed (issue #7 ).
